### PR TITLE
Add option to disable generating combinations of substitution pairs in MatchedGenerator

### DIFF
--- a/lmproof/candidate_generators.py
+++ b/lmproof/candidate_generators.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Set, Tuple
+from typing import List, Set, Dict
 
 import lemminflect
 import spacy
@@ -17,21 +17,10 @@ class CandidateEditGenerator:
 
 class MatchedGenerator(CandidateEditGenerator):
     def __init__(
-        self,
-        substitutions: List[Tuple[str, ...]],
-        spacy_model: spacy.language.Language,
-        generate_combinations: bool = True,
+        self, substitutions: Dict[str, Set[str]], spacy_model: spacy.language.Language,
     ):
         self._spacy = spacy_model
-        if generate_combinations:
-            self._word2substitutes = {
-                word: set(substs) for substs in substitutions for word in substs if word
-            }
-            print(f"w2s type: {type(self._word2substitutes)}")
-        else:  # Create one-to-one substitute mapping unidirectionally
-            self._word2substitutes = {
-                substitution[0]: {substitution[1]} for substitution in substitutions
-            }
+        self._word2substitutes = substitutions
 
     @classmethod
     def load(cls, language: str) -> "MatchedGenerator":

--- a/lmproof/candidate_generators.py
+++ b/lmproof/candidate_generators.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Set
+from typing import List, Set, Tuple, Union
 
 import lemminflect
 import spacy
@@ -17,13 +17,25 @@ class CandidateEditGenerator:
 
 class MatchedGenerator(CandidateEditGenerator):
     def __init__(
-        self, substitutions: List[Set[str]], spacy_model: spacy.language.Language
+        self,
+        substitutions: List[Union[Set[str], Tuple[str]]],
+        spacy_model: spacy.language.Language,
+        generate_combinations: bool = True,
     ):
         self._spacy = spacy_model
-        self._substitutions = substitutions
-        self._word2substitutes = {
-            word: substs for substs in substitutions for word in substs if word
-        }
+        if generate_combinations:
+            self._word2substitutes = {
+                word: substs for substs in substitutions for word in substs if word
+            }
+        else:
+            self._word2substitutes = {
+                substitution[0]: substitution[1] for substitution in substitutions
+            }
+        print("-"*50)
+        print(f"subsitutions:{substitutions}")
+        print("-"*50)
+        print(f"wrd2subs:{self._word2substitutes}")
+        print("\n\n")
 
     @classmethod
     def load(cls, language: str) -> "MatchedGenerator":

--- a/lmproof/candidate_generators.py
+++ b/lmproof/candidate_generators.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Set, Tuple, Union
+from typing import List, Set, Tuple, Union, Dict
 
 import lemminflect
 import spacy
@@ -18,18 +18,19 @@ class CandidateEditGenerator:
 class MatchedGenerator(CandidateEditGenerator):
     def __init__(
         self,
-        substitutions: List[Union[Set[str], Tuple[str]]],
+        substitutions: List[Tuple[str,...]],
         spacy_model: spacy.language.Language,
         generate_combinations: bool = True,
     ):
         self._spacy = spacy_model
         if generate_combinations:
             self._word2substitutes = {
-                word: substs for substs in substitutions for word in substs if word
+                word: set(substs) for substs in substitutions for word in substs if word
             }
-        else:
+            print(f"w2s type: {type(self._word2substitutes)}")
+        else: # Create one-to-one substitute mapping unidirectionally
             self._word2substitutes = {
-                substitution[0]: substitution[1] for substitution in substitutions
+                substitution[0]: {substitution[1]} for substitution in substitutions
             }
 
     @classmethod

--- a/lmproof/candidate_generators.py
+++ b/lmproof/candidate_generators.py
@@ -1,5 +1,5 @@
 import pathlib
-from typing import List, Set, Tuple, Union, Dict
+from typing import List, Set, Tuple
 
 import lemminflect
 import spacy
@@ -18,7 +18,7 @@ class CandidateEditGenerator:
 class MatchedGenerator(CandidateEditGenerator):
     def __init__(
         self,
-        substitutions: List[Tuple[str,...]],
+        substitutions: List[Tuple[str, ...]],
         spacy_model: spacy.language.Language,
         generate_combinations: bool = True,
     ):
@@ -28,7 +28,7 @@ class MatchedGenerator(CandidateEditGenerator):
                 word: set(substs) for substs in substitutions for word in substs if word
             }
             print(f"w2s type: {type(self._word2substitutes)}")
-        else: # Create one-to-one substitute mapping unidirectionally
+        else:  # Create one-to-one substitute mapping unidirectionally
             self._word2substitutes = {
                 substitution[0]: {substitution[1]} for substitution in substitutions
             }

--- a/lmproof/candidate_generators.py
+++ b/lmproof/candidate_generators.py
@@ -31,11 +31,6 @@ class MatchedGenerator(CandidateEditGenerator):
             self._word2substitutes = {
                 substitution[0]: substitution[1] for substitution in substitutions
             }
-        print("-"*50)
-        print(f"subsitutions:{substitutions}")
-        print("-"*50)
-        print(f"wrd2subs:{self._word2substitutes}")
-        print("\n\n")
 
     @classmethod
     def load(cls, language: str) -> "MatchedGenerator":

--- a/lmproof/substitutions.py
+++ b/lmproof/substitutions.py
@@ -1,14 +1,19 @@
 # pylint:disable=bad-continuation
-from typing import List, Tuple
+from typing import List, Set, Dict, Optional
 
 
-def english() -> List[Tuple[str, ...]]:
-    return [
+def english() -> Dict[str, Set[str]]:
+    substitutions = [
         # Article/Determiner
-        ("a", "an", "the", ""),
+        ["a", "an", "the", ""],
         # Prepositions
-        ("about", "at", "by", "for", "from", "in", "of", "on", "to", "with", ""),
+        ["about", "at", "by", "for", "from", "in", "of", "on", "to", "with", ""],
         # Commonly confused words
-        ("bear", "bare"),
-        ("lose", "loose"),
+        ["bear", "bare"],
+        ["lose", "loose"],
     ]
+    return {
+        each_element: set(replacement_list) - {each_element}
+        for replacement_list in substitutions
+        for each_element in replacement_list
+    }

--- a/lmproof/substitutions.py
+++ b/lmproof/substitutions.py
@@ -1,14 +1,14 @@
 # pylint:disable=bad-continuation
-from typing import List, Set
+from typing import List, Tuple
 
 
-def english() -> List[Set[str]]:
+def english() -> List[Tuple[str, ...]]:
     return [
         # Article/Determiner
-        {"a", "an", "the", ""},
+        ("a", "an", "the", ""),
         # Prepositions
-        {"about", "at", "by", "for", "from", "in", "of", "on", "to", "with", ""},
+        ("about", "at", "by", "for", "from", "in", "of", "on", "to", "with", ""),
         # Commonly confused words
-        {"bear", "bare"},
-        {"lose", "loose"},
+        ("bear", "bare"),
+        ("lose", "loose"),
     ]


### PR DESCRIPTION

gurunath.p
gurunath.p
Add option to disable generating combinations of substitution pairs i…
68da583

…n MatchedGenerator

---------------

* MatchedGenerator currently takes in a set of words and
  generates their combinations for replacing words from
  their possible replacements.
* For example, given a set {'bear', 'bare'}, it generates both
  the pairs {"bear" -> "bare"} and {"bare" -> "bear"} while
  considering replacements.
* But in some cases, only one-directional pair such as
  {'bare' -> 'bear'} in needed and the other pair is not needed. 
  This PR adds such option.